### PR TITLE
Add method to calculate node/edge ratio of k-hop method vs rw method

### DIFF
--- a/hypertuner.py
+++ b/hypertuner.py
@@ -30,7 +30,7 @@ class ManualTuner:
                                            data_appendix='', save_appendix=save_appendix, keep_old=False,
                                            continue_from=None,
                                            only_test=False, test_multiple_models=False, use_heuristic=use_heuristic,
-                                           m=m, M=M, dropedge=dropedge)
+                                           m=m, M=M, dropedge=dropedge, calc_ratio=False)
 
         run_sweal(sweal_parser)
 

--- a/models.py
+++ b/models.py
@@ -8,8 +8,8 @@ import torch
 from torch.nn import (ModuleList, Linear, Conv1d, MaxPool1d, Embedding, ReLU,
                       Sequential, BatchNorm1d as BN)
 import torch.nn.functional as F
-from torch_geometric.nn import (GCNConv, SAGEConv, GINConv,
-                                global_sort_pool, global_add_pool, global_mean_pool, MLP, global_max_pool)
+from torch_geometric.nn import GCNConv, SAGEConv, GINConv, global_sort_pool, global_add_pool, global_mean_pool, MLP, \
+    global_max_pool
 from torch_geometric.utils import dropout_adj
 
 


### PR DESCRIPTION
Usage: `python seal_link_pred.py --dataset ogbl-collab --hidden_channels 32 --runs 1 --num_hops 1 --model SAGE --use_feature --m 20 --M 200 --train_percent 0.05 --test_percent 0.05 --val_percent 0.05 --calc_ratio`